### PR TITLE
add config to hide window

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -33,4 +33,4 @@ TOP_LEFT_X = (WINDOW_WIDTH - BOARD_WIDTH) // 2
 TOP_LEFT_Y = WINDOW_HEIGHT - BOARD_HEIGHT
 
 
-
+SHOW_WINDOW = True  # switch to False to hide window display

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,8 @@ if __name__ == '__main__':
 
     pygame.font.init()
 
-    window = pygame.display.set_mode((WINDOW_WIDTH, WINDOW_HEIGHT))
+    window = pygame.display.set_mode((WINDOW_WIDTH, WINDOW_HEIGHT),
+        flags=0 if SHOW_WINDOW else pygame.HIDDEN)  # use the 'flags' argument to show or hide window
     pygame.display.set_caption('Tetris Game')
 
     run = True


### PR DESCRIPTION
Actually, this issue is easy to solve. Simply set
```python
pygame.display.set_mode(flags=pygame.HIDDEN)
```
will hide the frontend window.
I added an extra variable in ```config.py``` to let this variable be shared among multiple scripts.
You may read the [pygame doc](https://www.pygame.org/docs/ref/display.html) for more information.